### PR TITLE
Remove reference to distroless, expand purpose.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# meta
+# Meta
 
-This is just an issue tracker for concerns that affect the entire
-Distroless project.
+Please use this repo to file issues with Chainguard Images in general - issues with specific images
+should be filed on the repo for that image.
+
+## Image Requests
+
+Please open an issue if you'd like to request a new image.


### PR DESCRIPTION
Signed-off-by: Adrian Mouat <adrian@chainguard.dev>